### PR TITLE
Add fields option

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -2502,6 +2502,9 @@ class IssueStream(JiraStream):
         params: dict = {}
 
         params["maxResults"] = self.config.get("page_size", {}).get("issues", 10)
+        params["fields"] = (
+            self.config.get("stream_options", {}).get("issues", {}).get("fields")
+        )
 
         jql: list[str] = []
 

--- a/tap_jira/tap.py
+++ b/tap_jira/tap.py
@@ -67,6 +67,13 @@ class TapJira(Tap):
                             description="A JQL query to filter issues",
                             title="JQL Query",
                         ),
+                        th.Property(
+                            "fields",
+                            th.StringType,
+                            description="A comma-separated list of fields to include",
+                            title="Fields",
+                            default="*all",
+                        ),
                     ),
                     title="Issues Stream Options",
                     description="Options specific to the issues stream",


### PR DESCRIPTION
Add fields option. The default in the current search/jql endpoint is to only return id field!